### PR TITLE
feat: Enhanced DX by including thenable response and curry function

### DIFF
--- a/.changeset/strange-planets-mate.md
+++ b/.changeset/strange-planets-mate.md
@@ -1,0 +1,11 @@
+---
+"settle-map": major
+---
+
+# Update: Enhanced Response Handling
+
+- Removed the `all` getter in this release. With `settleMap` now returning a `Thenable` object, you can use the more intuitive `await` syntax without `all`.
+- Added a new `omitResult` option to prevent result storage. This is useful for saving memory when using the event-driven `on` function or when you would like to ignore it.
+- Implemented function overriding to manage the map function response based on the `omitResult` value.
+- Renamed the `stop` function to `abort` for clarity.
+- Introduced a new curry function, `createSettleMap`, to simplify code and adhere to the `DRY` (Don't Repeat Yourself) principle.

--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,10 @@
 src
 test
+
 .changeset
 .github
+.nvmrc
+
 pnpm-lock.yaml
 tsconfig.json
 vit.config.ts
-

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/fahimfaisaal/settle-map/.github%2Fworkflows%2Fmain.yml?branch=main&style=flat&logo=github-actions&label=CI) ![NPM Downloads](https://img.shields.io/npm/dm/settle-map?style=flat&logo=npm&logoColor=red&link=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2Fsettle-map) ![GitHub Repo stars](https://img.shields.io/github/stars/fahimfaisaal/settle-map?style=flat&logo=github&link=https%3A%2F%2Fgithub.com%2Ffahimfaisaal%2Fsettle-map)
 
-Settle Map is a tool that combines the features of `Promise.allSettled` and `Array.map`. It simplifies the process of mapping promises, providing results flexibility and lets you control how many can run at the same time using concurrency. In other words, it will help you prevent being rate-limited.
+Settle Map is a tool that combines the features of `Promise.allSettled` and `Array.map`. It simplifies the process of mapping promises, providing results flexibility with hassle free error handling and lets you control how many can run at the same time using concurrency. In other words, it will help you prevent being rate-limited.
 
 ## ⚙️ Installation
 
@@ -34,7 +34,7 @@ const settled = settleMap(
 Get response value on resolve any item immediately
 
 ```ts
-settled.on("resolve", ({ value, index }) => {
+settled.on("resolve", ({ value, item, index }) => {
   // your actions
 });
 ```
@@ -57,6 +57,8 @@ settled.on("retry", ({ error, retry, item, index }) => {
 
 Get the final result object
 
+> The `complete` event will not be emitted when `omitResult` options will be `true`.
+
 ```ts
 settled.on("complete", ({ values, error }) => {
   // your actions
@@ -68,11 +70,11 @@ settled.on("complete", ({ values, error }) => {
 
 ### Get the final result at once
 
-To wait and get all result at once an `all` getter return you the universal resolved promise
+To wait and get all result at once you just have to add `await` keyword like casual `async/await` approach or invoke the `then` method.
 
 ```ts
-const result = await settled.all; // An universal resolved promise
-console.log(result);
+const result = await settled; // An universal promise like syntax that returns only resolved response
+
 /* output
 {
   values: [1, 3, 5],
@@ -83,18 +85,18 @@ console.log(result);
 
 ### Wait Until All Processes Are Done
 
-If you want to wait until all processes are done, you can use the `.waitUntilFinished` method.
+If you want to wait until all processes are done, you can use the `waitUntilFinished` method.
 
 ```ts
 await settled.waitUntilFinished(); // will return always a resolved promise
 ```
 
-### Stop all process when you want
+### Abort all process when you need
 
-you could stop the all process any time and get the current result using `stop` method
+you could abort the all remaining processes any time and get the current result using `abort` method
 
 ```ts
-const result = settled.stop();
+const result = settled.abort();
 ```
 
 ### Get real time status
@@ -124,6 +126,7 @@ const options = {
     attempts: 3, // the number of attempts on fail
     delay: 2000, // ms
   },
+  omitResult: true, // the final result will be undefined incase it's true.
 };
 const settled = settleMap(items, asyncMapFunction, options);
 ```
@@ -138,17 +141,19 @@ A function that settles promises returned by the provided function (`fn`) for ea
 
 - `items` (`T[]`): An array of items to be processed.
 - `fn` (`(item: T, index: number) => Promise<R>`): A function that takes an item and its index as parameters and returns a Promise.
-- `options` (`SettleOptions | number`): An object that specifies the concurrency and retry options. If a number is provided, it is treated as the concurrency level. default option is `1`
+- `options` (`SettleOptions | number`): An object that specifies the concurrency and retry options. If a number is provided, it is treated as the concurrency level. Default is `1`
 
 #### Return Value
 
-Returns an object with the following properties and methods:
+Returns an object with the following methods:
 
-- `all`: A promise that resolves when all items have been processed and return the resolved and rejects items in a single object.
 - `waitUntilFinished()`: A method that returns a promise that resolves when all items have been processed, regardless of whether they succeeded or failed.
 - `status()`: A method that returns the current status of the settling process.
 - `on(event, listener)`: A method that allows you to listen for certain events.
-- `stop()`: A method that stops the settling process and return the current result.
+- `abort()`: A method that aborts all remain processes and return the current result.
+
+> [!NOTE]
+> Since the return value has `then` method so the `settleMap` function is awaitable. Followed the `Thenable` approach. [see MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables)
 
 ## 👤 Author (Fahim Faisaal)
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ Returns an object with the following methods:
 > [!NOTE]
 > Since the return value has `then` method so the `settleMap` function is awaitable. Followed the `Thenable` approach. [see MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables)
 
+### `createSettleMap(options)`
+
+A curry function of settleMap that will help you to set default options and use the map function with same option everywhere. even you could modify the options for each individual use.
+
 ## 👤 Author (Fahim Faisaal)
 
 - GitHub: [@fahimfaisaal](https://github.com/fahimfaisaal)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ settled.on("reject", ({ error, item, index }) => {
 Get response immediately on retry any item
 
 ```ts
-settled.on("retry", ({ error, retry, item, index }) => {
+settled.on("retry", ({ error, item, index, tried }) => {
   // your actions
 });
 ```

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
     "typescript": "^5.3.3",
     "vitest": "^1.2.0"
   },
+  "engineStrict": true,
+  "engines": {
+    "node": ">=16.14.0"
+  },
   "keywords": [
     "map",
     "promise",

--- a/src/create-settle-map.ts
+++ b/src/create-settle-map.ts
@@ -1,0 +1,18 @@
+import settleMap from ".";
+import type { SettleOptions } from "./types";
+import { mergeOptions } from "./utils";
+
+const createSettleMap =
+  (defaultOption: SettleOptions) =>
+  <T, R>(
+    items: T[],
+    fn: (item: T, index: number) => Promise<R>,
+    newOption?: number | Partial<SettleOptions>
+  ) =>
+    settleMap(
+      items,
+      fn,
+      mergeOptions(newOption ?? defaultOption, defaultOption)
+    );
+
+export default createSettleMap;

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -1,15 +1,35 @@
-import type { Emit, Listener } from "./types";
+import type { Listener } from "./types";
 
 class EventEmitter<T, R> {
-  public readonly listeners: Listener<T, R> = {};
+  public listeners: Listener<T, R> | null = null;
 
-  public readonly emit: Emit<T, R> = (event, args) => {
+  constructor() {
+    this.listeners = {};
+  }
+
+  public readonly emit = <E extends keyof Listener<T, R>>(
+    event: E,
+    args: Parameters<NonNullable<Listener<T, R>[E]>>[0]
+  ) => {
     try {
-      return this.listeners[event]?.(args as never);
+      return this.listeners?.[event]?.(args as never);
     } catch {
       return null;
     }
   };
+
+  public on<E extends keyof Listener<T, R>>(
+    event: E,
+    listener: (payload: Parameters<NonNullable<Listener<T, R>[E]>>[0]) => void
+  ) {
+    if (!this.listeners) return;
+
+    this.listeners[event] = listener;
+  }
+
+  public destroy() {
+    this.listeners = null;
+  }
 }
 
 export default EventEmitter;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import settleMap from "./settle-map";
+import createSettleMap from "./create-settle-map";
 
-export { settleMap };
+export { settleMap, createSettleMap };
 
 export default settleMap;

--- a/src/settle-map.ts
+++ b/src/settle-map.ts
@@ -1,26 +1,56 @@
-import type { SettleOptions } from "./types";
+import type { ReturnObjectType, Result, SettleOptions } from "./types";
 import { mergeOptions } from "./utils";
 import Settler from "./settler";
 
-const settleMap = <T, R>(
+// return void incase omitResult is true
+function settleMap<T, R>(
+  items: T[],
+  fn: (item: T, index: number) => Promise<R>,
+  options: SettleOptions & { omitResult: true }
+): ReturnObjectType<T, R> & {
+  then: (onfulfilled?: (value: undefined) => unknown) => Promise<unknown>;
+  abort: () => undefined;
+};
+
+// return result object incase omitResult is false or undefined
+function settleMap<T, R>(
+  items: T[],
+  fn: (item: T, index: number) => Promise<R>,
+  options?: number | (SettleOptions & { omitResult?: false | undefined })
+): ReturnObjectType<T, R> & {
+  then: (onfulfilled?: (value: Result<T, R>) => unknown) => Promise<unknown>;
+  abort: () => Result<T, R>;
+};
+
+function settleMap<T, R>(
   items: T[],
   fn: (item: T, index: number) => Promise<R>,
   options: SettleOptions | number = 1
-) => {
+) {
   const settler = new Settler<T, R>(mergeOptions(options));
   const promise = settler.settle(items, fn);
 
   return {
-    get all() {
-      return promise;
+    waitUntilFinished: async () => {
+      await settler.promise;
     },
-    waitUntilFinished: () => settler.waitUntilFinished(),
     status() {
-      return settler.status;
+      return {
+        activeCount: settler.limit.activeCount,
+        pendingCount: settler.limit.pendingCount,
+      };
     },
-    on: settler.on.bind(settler),
-    stop: () => settler.stop(),
+    on: settler.events.on.bind(settler.events),
+    abort: () => {
+      settler.limit.clearQueue();
+      settler.events.destroy();
+
+      return settler.result;
+    },
+    then(onfulfilled?: (value: Result<T, R> | undefined) => unknown) {
+      return promise.then(onfulfilled);
+    },
   };
-};
+}
 
 export default settleMap;

--- a/src/settle-map.ts
+++ b/src/settle-map.ts
@@ -16,7 +16,7 @@ function settleMap<T, R>(
 function settleMap<T, R>(
   items: T[],
   fn: (item: T, index: number) => Promise<R>,
-  options?: number | (SettleOptions & { omitResult?: false | undefined })
+  options?: number | SettleOptions
 ): ReturnObjectType<T, R> & {
   then: (onfulfilled?: (value: Result<T, R>) => unknown) => Promise<unknown>;
   abort: () => Result<T, R>;

--- a/src/settler.ts
+++ b/src/settler.ts
@@ -1,36 +1,27 @@
 import pLimit, { type Limit } from "p-limit";
 import { PayloadError, delay } from "./utils";
-import type {
-  SettleOptions,
-  PayloadType,
-  Listener,
-  EventListener,
-  Result,
-  Callback,
-} from "./types";
+import type { SettleOptions, PayloadType, Result, Callback } from "./types";
 import EventEmitter from "./emitter";
 
 class Settler<T, R> {
   private readonly promises: Promise<
     ReturnType<typeof this.limit> | unknown
   >[] = [];
-  private readonly result: Result<T, R> = {
-    values: [],
-    errors: [],
-  };
-  private readonly events = new EventEmitter<T, R>();
-  private readonly limit: Limit;
+  private processed = 0;
+
+  public readonly result: Result<T, R> | undefined;
+  public readonly limit: Limit;
+
+  public readonly events = new EventEmitter<T, R>();
+  public promise = Promise.all(this.promises);
 
   constructor(public readonly options: SettleOptions) {
     this.validateOptions(options);
     this.limit = pLimit(options.concurrency);
-  }
 
-  get status() {
-    return {
-      activeCount: this.limit.activeCount,
-      pendingCount: this.limit.pendingCount,
-    };
+    if (!this.options.omitResult) {
+      this.result = { values: [], errors: [] };
+    }
   }
 
   private validateOptions(options: SettleOptions) {
@@ -47,16 +38,6 @@ class Settler<T, R> {
     }
   }
 
-  public stop() {
-    this.limit.clearQueue();
-
-    return this.result;
-  }
-
-  public async waitUntilFinished() {
-    await Promise.all(this.promises);
-  }
-
   private handleItem(
     item: T,
     index: number,
@@ -67,7 +48,7 @@ class Settler<T, R> {
       try {
         const value = await fn(item, index);
         this.events.emit("resolve", { value, item, index });
-        this.result.values.push(value);
+        this.result?.values.push(value);
       } catch (error) {
         if (retry >= 1) {
           this.events.emit("retry", {
@@ -83,7 +64,7 @@ class Settler<T, R> {
           return this.handleItem(item, index, fn, retry - 1)();
         }
 
-        this.result.errors.push(
+        this.result?.errors.push(
           new PayloadError<PayloadType<T>>((error as Error).message, {
             item,
             index,
@@ -94,6 +75,15 @@ class Settler<T, R> {
           item,
           index,
         });
+      } finally {
+        this.processed++;
+
+        if (this.processed === this.promises.length) {
+          !this.options.omitResult &&
+            this.events.emit("complete", this.result as Result<T, R>);
+          this.events.destroy();
+          this.processed = 0;
+        }
       }
     };
   }
@@ -103,16 +93,10 @@ class Settler<T, R> {
       this.promises.push(this.limit(this.handleItem(item, index, fn)));
     }
 
-    await Promise.all(this.promises);
-    this.events.emit("complete", this.result);
-    return this.result;
-  }
+    this.promise = Promise.all(this.promises);
+    await this.promise;
 
-  public on<E extends keyof Listener<T, R>>(
-    event: E,
-    listener: EventListener<T, R, E>
-  ) {
-    this.events.listeners[event] = listener;
+    return this.result;
   }
 }
 

--- a/src/settler.ts
+++ b/src/settler.ts
@@ -55,7 +55,7 @@ class Settler<T, R> {
             error: error as Error,
             item,
             index,
-            retry,
+            tried: (this.options.onFail?.attempts ?? retry) - retry + 1,
           });
 
           this.options.onFail?.delay &&

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface Listener<T, R> {
     error: Error;
     item: T;
     index: number;
-    retry: number;
+    tried: number;
   }) => void;
   complete?: (payload: ReturnType<T, R>) => void;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type SettleOptions = {
     attempts: number;
     delay?: number;
   };
+  omitResult?: boolean;
 };
 
 export type StatusType = {
@@ -30,10 +31,6 @@ export type Result<T, R> = {
   errors: PayloadError<PayloadType<T>>[];
 };
 
-export type EventListener<T, R, E extends keyof Listener<T, R>> = (
-  payload: Parameters<NonNullable<Listener<T, R>[E]>>[0]
-) => void;
-
 export type PayloadType<T> = { item: T; index: number };
 
 export type ReturnType<T, R> = {
@@ -41,9 +38,13 @@ export type ReturnType<T, R> = {
   errors: PayloadError<PayloadType<T>>[];
 };
 
-export type Emit<T, R> = (
-  event: keyof Listener<T, R>,
-  args: Parameters<NonNullable<Listener<T, R>[keyof Listener<T, R>]>>[0]
-) => void;
-
 export type Callback<T, R> = (item: T, index: number) => Promise<R>;
+
+export type ReturnObjectType<T, R> = {
+  waitUntilFinished(): Promise<void>;
+  status(): { activeCount: number; pendingCount: number };
+  on: <K extends keyof Listener<T, R>>(
+    event: K,
+    listener: Listener<T, R>[K]
+  ) => void;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,27 +6,29 @@ export class PayloadError<TPayload> extends Error {
   }
 }
 
-export const mergeOptions = (
-  options: SettleOptions | number
-): SettleOptions => {
-  const defaultOptions = {
-    concurrency: 1,
-    onFail: {
-      attempts: 0,
-      delay: 0,
-    },
-    omitResult: false,
-  };
+const defaultOptions: SettleOptions = {
+  concurrency: 1,
+  onFail: {
+    attempts: 0,
+    delay: 0,
+  },
+  omitResult: false,
+};
 
+export const mergeOptions = (
+  options: Partial<SettleOptions> | number,
+  oldOptions = defaultOptions
+): SettleOptions => {
   if (typeof options === "number") {
-    return { ...defaultOptions, concurrency: options };
+    return { ...oldOptions, concurrency: options };
   }
 
   return {
-    ...defaultOptions,
+    ...oldOptions,
     ...options,
     onFail: {
-      ...defaultOptions.onFail,
+      attempts: options.onFail?.attempts ?? 0,
+      ...oldOptions.onFail,
       ...options.onFail,
     },
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,7 @@ export const mergeOptions = (
       attempts: 0,
       delay: 0,
     },
+    omitResult: false,
   };
 
   if (typeof options === "number") {

--- a/test/create-settle-map.test.ts
+++ b/test/create-settle-map.test.ts
@@ -1,0 +1,97 @@
+import { it, test, expect, describe, vi, beforeEach } from "vitest";
+import { createSettleMap } from "../src";
+import { PayloadError } from "../src/utils";
+import type { Result } from "../src/types";
+
+test("should create a function", () => {
+  expect(createSettleMap).toBeInstanceOf(Function);
+});
+
+describe("Test functionalities of createSettleMap", () => {
+  let map: ReturnType<typeof createSettleMap>;
+
+  beforeEach(() => {
+    map = createSettleMap({
+      concurrency: 5,
+    });
+  });
+
+  it("should work despite no options passed", async () => {
+    expect(await map([1, 2, 3], async (item) => item)).toEqual({
+      values: [1, 2, 3],
+      errors: [],
+    });
+  });
+
+  it("should work with merge options", async () => {
+    expect(
+      await map([1, 2, 3], async (item) => item, { omitResult: true })
+    ).toBeUndefined();
+    expect(await map([1, 2, 3], async (item) => item, 2)).toEqual({
+      values: [1, 2, 3],
+      errors: [],
+    });
+  });
+
+  it("should emit all events correctly", async () => {
+    const items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const valuesAndErrors = items.map((item, index) => {
+      if (item % 2 !== 0) {
+        return item * 2;
+      }
+
+      return new PayloadError("test", { item, index });
+    });
+    const valuesIter = valuesAndErrors
+      .filter((value) => !(value instanceof PayloadError))
+      .values();
+    const errorsIter = valuesAndErrors
+      .filter((value) => value instanceof PayloadError)
+      .values();
+
+    const resolveMockFunc = vi.fn();
+    const rejectMockFunc = vi.fn();
+    const completeMockFunc = vi.fn();
+
+    const settled = map(items, async (item) => {
+      if (item % 2 !== 0) {
+        return item * 2;
+      }
+
+      throw new Error("test");
+    });
+
+    settled.on("resolve", resolveMockFunc);
+    settled.on("reject", rejectMockFunc);
+    settled.on("complete", completeMockFunc);
+
+    await settled.waitUntilFinished();
+
+    resolveMockFunc.mock.calls.forEach((call) => {
+      expect(call[0].value).toBe(valuesIter.next().value);
+    });
+
+    rejectMockFunc.mock.calls.forEach((call) => {
+      expect(call[0].error).toBeInstanceOf(Error);
+      const { value } = errorsIter.next();
+
+      expect(call[0].item).toBe(value.payload.item);
+      expect(call[0].index).toBe(value.payload.index);
+    });
+
+    expect(completeMockFunc).toHaveBeenCalledWith(
+      valuesAndErrors.reduce(
+        (result, value) => {
+          if (value instanceof PayloadError) {
+            result.errors.push(value);
+          } else {
+            result.values.push(value);
+          }
+
+          return result;
+        },
+        { values: [], errors: [] } as Result<number, number>
+      )
+    );
+  });
+});

--- a/test/emitter.test.ts
+++ b/test/emitter.test.ts
@@ -33,7 +33,7 @@ describe("it all emit methods", () => {
       error: new Error("it"),
       item: "it",
       index: 0,
-      retry: 0,
+      tried: 0,
       status: { activeCount: 0, pendingCount: 0 },
     },
     complete: {

--- a/test/emitter.test.ts
+++ b/test/emitter.test.ts
@@ -10,6 +10,8 @@ test("should create an instance of EventEmitter", () => {
 test("should initialize with an empty listeners object", () => {
   const emitter = new EventEmitter<string, number>();
   expect(emitter.listeners).toEqual({});
+  emitter.destroy();
+  expect(emitter.listeners).toBeNull();
 });
 
 describe("it all emit methods", () => {
@@ -59,10 +61,10 @@ describe("it all emit methods", () => {
       throw new Error("move error");
     };
 
-    emitter.listeners["resolve"] = mockErrorListener;
-    emitter.listeners["reject"] = mockErrorListener;
-    emitter.listeners["retry"] = mockErrorListener;
-    emitter.listeners["complete"] = mockErrorListener;
+    emitter.on("resolve", mockErrorListener);
+    emitter.on("reject", mockErrorListener);
+    emitter.on("retry", mockErrorListener);
+    emitter.on("complete", mockErrorListener);
 
     expect(emitter.emit("resolve", payloads.resolve)).toBeNull();
     expect(emitter.emit("reject", payloads.reject)).toBeNull();
@@ -73,28 +75,28 @@ describe("it all emit methods", () => {
   const mockListenerFunc = vi.fn();
 
   it("should call the listener with correct payload when the resolve event is emitted", () => {
-    emitter.listeners["resolve"] = mockListenerFunc;
+    emitter.on("resolve", mockListenerFunc);
 
     emitter.emit("resolve", payloads.resolve);
     expect(mockListenerFunc).toHaveBeenCalledWith(payloads.resolve);
   });
 
   it("should call the listener with correct payload when the reject event is emitted", () => {
-    emitter.listeners["reject"] = mockListenerFunc;
+    emitter.on("reject", mockListenerFunc);
 
     emitter.emit("reject", payloads.reject);
     expect(mockListenerFunc).toHaveBeenCalledWith(payloads.reject);
   });
 
   it("should call the listener with correct payload when the retry event is emitted", () => {
-    emitter.listeners["retry"] = mockListenerFunc;
+    emitter.on("retry", mockListenerFunc);
 
     emitter.emit("retry", payloads.retry);
     expect(mockListenerFunc).toHaveBeenCalledWith(payloads.retry);
   });
 
   it("should call the listener with correct payload when the complete event is emitted", () => {
-    emitter.listeners["complete"] = mockListenerFunc;
+    emitter.on("complete", mockListenerFunc);
 
     emitter.emit("complete", payloads.complete as never);
     expect(mockListenerFunc).toHaveBeenCalledWith(payloads.complete);

--- a/test/settler-map.test.ts
+++ b/test/settler-map.test.ts
@@ -7,18 +7,29 @@ test("should settle promises and return results", async () => {
   const items = [1, 2, 3, 4, 5];
   const settle = settleMap(items, async (item) => item);
 
-  expect(settle.all).instanceOf(Promise);
-  expect(settle.stop).instanceOf(Function);
+  expect(settle.abort).instanceOf(Function);
   expect(settle.on).instanceOf(Function);
-  expect(await settle.all).toEqual({
+  expect(settle.waitUntilFinished).instanceOf(Function);
+  expect(settle.status).instanceOf(Function);
+  expect(await settle).toEqual({
     values: items,
     errors: [],
   });
 });
 
+test("should return undefined when omitResult is true", async () => {
+  const items = [1, 2, 3, 4, 5];
+  const settle = settleMap(items, async (item) => item, {
+    omitResult: true,
+    concurrency: 3,
+  });
+
+  expect(await settle).toBeUndefined();
+});
+
 test("should settle promises and return results with all method", async () => {
   const items = [1, 2, 3, 4, 5];
-  const result = await settleMap(items, async (item) => item, 2).all;
+  const result = await settleMap(items, async (item) => item, 2);
 
   expect(result).toEqual({
     values: items,
@@ -33,7 +44,7 @@ test("should return correct status", () => {
   expect(settle.status().pendingCount).toBe(5);
   expect(settle.status().activeCount).toBe(0);
 
-  settle.stop();
+  settle.abort();
 
   expect(settle.status().pendingCount).toBe(0);
   expect(settle.status().activeCount).toBe(0);

--- a/test/settler.test.ts
+++ b/test/settler.test.ts
@@ -37,21 +37,11 @@ describe("Settler class", () => {
     expect(settler.options.onFail?.delay).toBeUndefined();
   });
 
-  it("should return correct status", () => {
-    const status = settler.status;
-    expect(status.activeCount).toBe(0);
-    expect(status.pendingCount).toBe(0);
-  });
-
-  it("should stop the queue", async () => {
-    settler.settle([1, 2, 3], async (item) => item);
-    settler.stop();
-    expect(settler.status.pendingCount).toBe(0);
-    expect(settler.status.activeCount).toBe(0);
-  });
-
   it("should settle promises and return results", async () => {
-    const res = await settler.settle([1, 2, 3, 4, 5], async (item) => item * 2);
+    const res = (await settler.settle(
+      [1, 2, 3, 4, 5],
+      async (item) => item * 2
+    )) as Result<number, number>;
     expect(res.values).toEqual([2, 4, 6, 8, 10]);
     expect(res.errors).toEqual([]);
   });
@@ -76,9 +66,9 @@ describe("Settler class", () => {
     const rejectMockFunc = vi.fn();
     const completeMockFunc = vi.fn();
 
-    settler.on("resolve", resolveMockFunc);
-    settler.on("reject", rejectMockFunc);
-    settler.on("complete", completeMockFunc);
+    settler.events.on("resolve", resolveMockFunc);
+    settler.events.on("reject", rejectMockFunc);
+    settler.events.on("complete", completeMockFunc);
 
     settler.settle(items, async (item) => {
       if (item % 2 !== 0) {
@@ -88,7 +78,7 @@ describe("Settler class", () => {
       throw new Error("test");
     });
 
-    await settler.waitUntilFinished();
+    await settler.promise;
 
     resolveMockFunc.mock.calls.forEach((call) => {
       expect(call[0].value).toBe(valuesIter.next().value);

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -16,18 +16,26 @@ test("should merge options correctly with number only", () => {
   expect(options.concurrency).toBe(2);
   expect(options.onFail?.attempts).toBe(0);
   expect(options.onFail?.delay).toBe(0);
+  expect(options.omitResult).toBe(false);
 });
 
 test("should merge options correctly with object", () => {
   const options = mergeOptions({
-    concurrency: 2,
     onFail: {
       attempts: 2,
       delay: 1000,
     },
+    omitResult: true,
   });
 
-  expect(options.concurrency).toBe(2);
+  expect(options.concurrency).toBe(1);
   expect(options.onFail?.attempts).toBe(2);
   expect(options.onFail?.delay).toBe(1000);
+  expect(options.omitResult).toBe(true);
 });
+
+/**
+ * how to run test
+ * version traking on challenge feature
+ * lerna version patch
+ */


### PR DESCRIPTION
- Removed the `all` getter in this release. With `settleMap` now returning a `Thenable` object, you can use the more intuitive `await` syntax without `all`.
- Added a new `omitResult` option to prevent result storage. This is useful for saving memory when using the event-driven `on` function or when you would like to ignore it.
- Implemented function overriding to manage the map function response based on the `omitResult` value.
- Renamed the `stop` function to `abort` for clarity.
- Introduced a new curry function, `createSettleMap`, to simplify code and adhere to the `DRY` (Don't Repeat Yourself) principle.